### PR TITLE
Volatile/decompose student contact201910

### DIFF
--- a/bin/loadStudentFileIntoSQL.pl
+++ b/bin/loadStudentFileIntoSQL.pl
@@ -292,6 +292,45 @@ sub processSimpleResults($$)
     return($returnedID);
 }
 
+sub getContactEmailID($$$$$$$)
+{
+    my ($dbh, $emailAddress, $contactID, $studentID, $schoolID, $homeroomID, $familyCodeID) = @_;
+    my $query = <<FINI;
+    insert into email(address)
+	values(?)
+	on duplicate key
+    update email_id=LAST_INSERT_ID(email_id);
+    select last_insert_id();
+    insert ignore into student_contact_email(email_id, student_contact_id)
+	values (last_insert_id(), ?);
+FINI
+
+    my $statement = $dbh->prepare($query) or die("Unable to prepare query " . $query . ": " . $dbh->err . ": " . $dbh->errstr);
+    {
+	my $pindex = 0;
+	$statement->bind_param(++$pindex, $emailAddress);
+	$statement->bind_param(++$pindex, $contactID);
+    }
+    return(processSimpleResults($statement, 2));
+    
+}
+
+sub getContact1EmailID($$$$$$$)
+{
+    my ($dbh, $student, $contact1ID, $studentID, $schoolID, $homeroomID, $familyCodeID) = @_;
+    my $emailAddress = $student->{'G1 Email'};
+    return(getContactEmailID($dbh, $emailAddress, $contact1ID, $studentID, $schoolID, $homeroomID, $familyCodeID));
+    
+}
+
+sub getContact2EmailID($$$$$$$)
+{
+    my ($dbh, $student, $contact1ID, $studentID, $schoolID, $homeroomID, $familyCodeID) = @_;
+    my $emailAddress = $student->{'G2 Email'};
+    return(getContactEmailID($dbh, $emailAddress, $contact1ID, $studentID, $schoolID, $homeroomID, $familyCodeID));
+    
+}
+
 
 sub getContactID($$$$$$)
 {
@@ -317,6 +356,8 @@ FINI
     return(processSimpleResults($statement, 2));
 
 }
+
+
 sub getContact1ID($$$$$$)
 {
     my ($dbh, $student, $studentID, $schoolID, $homeroomID, $familyCodeID) = @_;
@@ -548,6 +589,8 @@ FINI
 				my $contact1ID = getContact1ID($dbh, $rowData, $studentID, $schoolID, $homeroomID, $familyCodeID);
 				my $contact2ID = getContact2ID($dbh, $rowData, $studentID, $schoolID, $homeroomID, $familyCodeID);
 
+				my $email1ID = getContact1EmailID($dbh, $rowData, $contact1ID, $studentID, $schoolID, $homeroomID, $familyCodeID);
+				my $email2ID = getContact2EmailID($dbh, $rowData, $contact2ID, $studentID, $schoolID, $homeroomID, $familyCodeID);
 				print 'Student ID: ', $studentID, 
 					' Contact IDs: ', $contact1ID, ' and ', $contact2ID, 
 					"\n";

--- a/bin/loadStudentFileIntoSQL.pl
+++ b/bin/loadStudentFileIntoSQL.pl
@@ -299,29 +299,32 @@ sub saveContactPhone($$$$$$)
     if (defined($phoneNumber) && ($phoneNumber !~ /^\s*$/))
     {
 	my $query = <<FINI;
-	    insert into phone(number, prime, home, cellular)
-	    	values (?, ?, ?, ?)
+	    insert into phone(number)
+	    	values (?)
 	    on duplicate key
-	    update phone_id = LAST_INSERT_ID(phone_id), 
+	    update phone_id = LAST_INSERT_ID(phone_id);
+	    select last_insert_id();
+	    insert into student_contact_phone(phone_id, student_contact_id, 
+					      prime, home, cellular)
+		values (last_insert_id(), ?, ?, ?, ?)
+	    on duplicate key
+	    update
 		prime = ifnull(?, prime),
 		home = ifnull(?, home),
 		cellular = ifnull(?, cellular);
-	    select last_insert_id();
-	    insert ignore into student_contact_phone(phone_id, student_contact_id)
-		values (last_insert_id(), ?);
 FINI
 
 	my $statement = $dbh->prepare($query) or die("Unable to prepare query " . $query . ": " . $dbh->err . ": " . $dbh->errstr);
 	{
 	    my $pindex = 0;
 	    $statement->bind_param(++$pindex, $phoneNumber);
-	    $statement->bind_param(++$pindex, $isPrimary);
-	    $statement->bind_param(++$pindex, $isHome);
-	    $statement->bind_param(++$pindex, $isCell);
-	    $statement->bind_param(++$pindex, $isPrimary);
-	    $statement->bind_param(++$pindex, $isHome);
-	    $statement->bind_param(++$pindex, $isCell);
 	    $statement->bind_param(++$pindex, $contactID);
+	    $statement->bind_param(++$pindex, $isPrimary);
+	    $statement->bind_param(++$pindex, $isHome);
+	    $statement->bind_param(++$pindex, $isCell);
+	    $statement->bind_param(++$pindex, $isPrimary);
+	    $statement->bind_param(++$pindex, $isHome);
+	    $statement->bind_param(++$pindex, $isCell);
 	}
 	$rval = processSimpleResults($statement, 2);
 	    	

--- a/bin/loadStudentFileIntoSQL.pl
+++ b/bin/loadStudentFileIntoSQL.pl
@@ -302,12 +302,18 @@ sub getContactID($$$$$$)
 	values(?, ?)
 	on duplicate key
     update student_contact_id=LAST_INSERT_ID(student_contact_id);
-    select last_insert_id;
+    select last_insert_id();
+    insert ignore into student_student_contact(student_contact_id, student_id)
+	values (last_insert_id(), ?);
 FINI
 
     my $statement = $dbh->prepare($query) or die("Unable to prepare query " . $query . ": " . $dbh->err . ": " . $dbh->errstr);
-    $statement->bind_param(1, $firstName);
-    $statement->bind_param(2, $lastName);
+    {
+	my $pindex = 0;
+	$statement->bind_param(++$pindex, $firstName);
+	$statement->bind_param(++$pindex, $lastName);
+	$statement->bind_param(++$pindex, $studentID);
+    }
     return(processSimpleResults($statement, 2));
 
 }
@@ -542,7 +548,9 @@ FINI
 				my $contact1ID = getContact1ID($dbh, $rowData, $studentID, $schoolID, $homeroomID, $familyCodeID);
 				my $contact2ID = getContact2ID($dbh, $rowData, $studentID, $schoolID, $homeroomID, $familyCodeID);
 
-				print "Student ID: ", $studentID, "\n";
+				print 'Student ID: ', $studentID, 
+					' Contact IDs: ', $contact1ID, ' and ', $contact2ID, 
+					"\n";
 			    };
 			    if ($@)
 			    {

--- a/db/createdb/1.create
+++ b/db/createdb/1.create
@@ -113,14 +113,78 @@ create table student_contact
 	first_name	varchar(50) not null,
 	last_name	varchar(50) not null,
 
+	use_in_directory	    boolean null,
+	use_in_broadcast	    boolean null
+);
+
+create table address
+(
+	address_id	INT AUTO_INCREMENT NOT NULL,
+	primary key(address_id),
+
 	street_number	varchar(50) not null,
 	street_name	varchar(50) not null,
 	city		varchar(50) not null,
 	state		varchar(50) not null,
-	zip		varchar(50) not null,
-	email		varchar(50) not null,
-	primary_phone	varchar(50) not null,
-	home_phone	varchar(50) not null,
-	cell_phone	varchar(50) not null,
-	house		varchar(50) not null
+	zip		varchar(50) not null
 );
+
+create table student_contact_address
+(
+	student_contact_id	int not null,
+	foreign key (student_contact_id) references student_contact(student_contact_id),
+
+	address_id  		int not null,
+	foreign key (address_id) references address(address_id)
+);
+
+	
+create table phone
+(
+	phone_id	INT AUTO_INCREMENT NOT NULL,
+	primary key(phone_id),
+
+	
+	number		varchar(50) not null,
+	cellular	boolean null,
+	home		boolean null,
+	house		boolean null
+
+);
+
+create table student_contact_phone
+(
+	student_contact_id	int not null,
+	foreign key (student_contact_id) references student_contact(student_contact_id),
+
+	phone_id  		int not null,
+	foreign key (phone_id) references phone(phone_id)
+);
+
+
+create table email
+(
+	email_id	INT AUTO_INCREMENT NOT NULL,
+	primary key(email_id),
+
+	address		varchar(200) not null,
+	personal	boolean null,
+	work		boolean null
+);
+
+create table student_contact_email
+(
+	student_contact_id	int not null,
+	foreign key (student_contact_id) references student_contact(student_contact_id),
+
+	email_id  		int not null,
+	foreign key (email_id) references email(email_id)
+);
+
+
+
+	
+
+
+
+

--- a/db/createdb/1.create
+++ b/db/createdb/1.create
@@ -182,7 +182,7 @@ create table email
 	email_id	INT AUTO_INCREMENT NOT NULL,
 	primary key(email_id),
 
-	address		varchar(200) not null
+	address		varchar(200) not null unique
 );
 
 create table student_contact_email
@@ -191,7 +191,9 @@ create table student_contact_email
 	foreign key (student_contact_id) references student_contact(student_contact_id),
 
 	email_id  		int not null,
-	foreign key (email_id) references email(email_id)
+	foreign key (email_id) references email(email_id), 
+	unique key (student_contact_id, email_id)
+
 );
 
 

--- a/db/createdb/1.create
+++ b/db/createdb/1.create
@@ -118,6 +118,20 @@ create table student_contact
 	use_in_broadcast	    boolean null
 );
 
+create table student_student_contact
+(
+	student_contact_id	int not null references student_contact(student_contact_id), 
+	student_id		int not null references student(student_id),
+
+	unique key (student_contact_id, student_id), 
+
+	-- Support quick joining in either direction
+	key (student_contact_id), 
+	key (student_id)
+);
+
+
+
 create table address
 (
 	address_id	INT AUTO_INCREMENT NOT NULL,

--- a/db/createdb/1.create
+++ b/db/createdb/1.create
@@ -150,7 +150,9 @@ create table student_contact_address
 	foreign key (student_contact_id) references student_contact(student_contact_id),
 
 	address_id  		int not null,
-	foreign key (address_id) references address(address_id)
+	foreign key (address_id) references address(address_id),
+
+	unique key (student_contact_id, address_id)
 );
 
 	
@@ -160,10 +162,10 @@ create table phone
 	primary key(phone_id),
 
 	
-	number		varchar(50) not null,
+	number		varchar(50) not null unique,
 	cellular	boolean null,
 	home		boolean null,
-	house		boolean null
+	prime		boolean null
 
 );
 
@@ -173,7 +175,9 @@ create table student_contact_phone
 	foreign key (student_contact_id) references student_contact(student_contact_id),
 
 	phone_id  		int not null,
-	foreign key (phone_id) references phone(phone_id)
+	foreign key (phone_id) references phone(phone_id),
+
+	unique key (student_contact_id, phone_id)
 );
 
 
@@ -192,8 +196,8 @@ create table student_contact_email
 
 	email_id  		int not null,
 	foreign key (email_id) references email(email_id), 
-	unique key (student_contact_id, email_id)
 
+	unique key (student_contact_id, email_id)
 );
 
 

--- a/db/createdb/1.create
+++ b/db/createdb/1.create
@@ -112,6 +112,7 @@ create table student_contact
 
 	first_name	varchar(50) not null,
 	last_name	varchar(50) not null,
+	unique key (first_name, last_name), 
 
 	use_in_directory	    boolean null,
 	use_in_broadcast	    boolean null

--- a/db/createdb/1.create
+++ b/db/createdb/1.create
@@ -182,9 +182,7 @@ create table email
 	email_id	INT AUTO_INCREMENT NOT NULL,
 	primary key(email_id),
 
-	address		varchar(200) not null,
-	personal	boolean null,
-	work		boolean null
+	address		varchar(200) not null
 );
 
 create table student_contact_email

--- a/db/createdb/1.create
+++ b/db/createdb/1.create
@@ -161,11 +161,7 @@ create table phone
 	phone_id	INT AUTO_INCREMENT NOT NULL,
 	primary key(phone_id),
 
-	
-	number		varchar(50) not null unique,
-	cellular	boolean null,
-	home		boolean null,
-	prime		boolean null
+	number		varchar(50) not null unique
 
 );
 
@@ -176,6 +172,10 @@ create table student_contact_phone
 
 	phone_id  		int not null,
 	foreign key (phone_id) references phone(phone_id),
+
+	cellular	boolean null,
+	home		boolean null,
+	prime		boolean null,
 
 	unique key (student_contact_id, phone_id)
 );

--- a/db/createdb/1.drop
+++ b/db/createdb/1.drop
@@ -14,6 +14,9 @@ drop table if exists student_contact_phone;
 \! echo "Drop phone"
 drop table if exists phone;
 
+\! echo "Drop student_student_contact"
+drop table if exists student_student_contact;
+
 \! echo "Drop student_contact"
 drop table if exists student_contact;
 

--- a/db/createdb/1.drop
+++ b/db/createdb/1.drop
@@ -1,5 +1,23 @@
+
+\! echo "Drop student_contact_address"
+drop table if exists student_contact_address;
+\! echo "Drop address"
+drop table if exists address;
+
+\! echo "Drop student_contact_email"
+drop table if exists student_contact_email;
+\! echo "Drop email"
+drop table if exists email;
+
+\! echo "Drop student_contact_phone"
+drop table if exists student_contact_phone;
+\! echo "Drop phone"
+drop table if exists phone;
+
 \! echo "Drop student_contact"
 drop table if exists student_contact;
+
+
 \! echo "Drop student"
 drop table if exists student;
 \! echo "Drop homeroom"


### PR DESCRIPTION
This should include resolutions for issues #2 and #3.  Information about student contacts is heavily decomposed (or normalized, in RDB-speak {8^).  The loader can differentiate between the data file of contacts to be used for email broadcasting and the data file of contacts to be used in the production of a printed directory.

Note that physical address, while present in the schema, is not used at all.  This is because the district has ceased sending us this data, at least as of now.